### PR TITLE
take /langid into account when replacing a resource with /rf

### DIFF
--- a/ReadMe-verpatch.txt
+++ b/ReadMe-verpatch.txt
@@ -41,7 +41,7 @@ Other options:
 
 /fn - preserves Original filename, Internal name in the existing version resource of the file.
 /langid <number> - language id for new version resource.
-     Use with /va. Default is Language Neutral.
+     Use with /va or /rf. Default is Language Neutral.
      <number> is combination of primary and sublanguage IDs. ENU is 1033 or 0x409.
 /vo - outputs the version info in RC format to stdout.
      This can be used with /xi to dump a version resource without modification.
@@ -98,7 +98,9 @@ Low 16 bits of this value are resource id; can not be 0.
 Next 8 bits are resource type: one of RT_xxx symbols in winuser.h, or user defined.
 If the type value is 0, RT_RCDATA (10) is assumed.
 High 8 bits of the #id arg are reserved0.
-The language code of resources added by this switch is 0 (Neutral).
+The language code of resources added by this switch is 0 (Neutral) by default, and you
+can change it using the /langid option. For example, specify /langid 0x409 along with
+/rf to add/modify ENU resources.
 Named resource types and ids are not implemented.
 The file is added as opaque binary chunk; the resource size is rounded up to 4 bytes
 and padded with zero bytes.

--- a/relstamp.cpp
+++ b/relstamp.cpp
@@ -44,7 +44,7 @@ struct ResDesc
 		: m_data((PUCHAR)data), m_cbdata(cbData), m_type(typeId), 
 			m_name(name_id), m_language(langId)	{}
 
-	friend bool addResourceFromFile( PCTSTR resfile, UINT32 id_flags );
+	friend bool addResourceFromFile( PCTSTR resfile, UINT32 id_flags, LANGID langid );
 };
 
 static 
@@ -683,7 +683,7 @@ bool cmd_params::cmd_arg_parse( int argc, _TCHAR *argv[], PCTSTR *fname,
 
 				ap = argv[++i];	ASSERT( ap && *ap != _T('/') && *ap != _T('-') );
 				// only during 2nd pass:
-				if ( !firstPass && !addResourceFromFile( ap, res_id ) ) {
+				if ( !firstPass && !addResourceFromFile( ap, res_id, g_params.LangId ) ) {
 					dtprint(_T("Error adding resource file [%s] id=%#X\n"), ap, res_id);
 					return false;
 				}
@@ -819,7 +819,7 @@ bool argmatch(PCTSTR sw, PCTSTR cmp )
 // Add raw binary resource from file.
 // Low 16 bit of id_flags = resource ID. Bitmask FF0000 = type (0=RCDATA). High byte reserved.
 //////////////////////////////////////////////////////////////////////////
-bool addResourceFromFile( PCTSTR resfile, UINT32 id_flags )
+bool addResourceFromFile( PCTSTR resfile, UINT32 id_flags, LANGID langid )
 {
 	UINT64 xFileSize;
 	HANDLE fh = CreateFile(resfile, GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, 0, NULL);
@@ -860,7 +860,7 @@ bool addResourceFromFile( PCTSTR resfile, UINT32 id_flags )
 	ULONG restype = (id_flags >> 16) & 0xFF;
 	if ( 0 == restype ) restype = (ULONG)RT_RCDATA;
 
-	addUpdRes( new ResDesc( dp, dwFileSize, restype, id_flags & 0xFFFF ) );
+	addUpdRes( new ResDesc( dp, dwFileSize, restype, id_flags & 0xFFFF, langid ) );
 
 	return true;	
 }


### PR DESCRIPTION
I came across the case when I need to replace an icon that has EN-US (1033) language ID in an existing .exe file. This branch adds support for using /langid supplied on a command line with /rf in such a case. Previously /langid was only used along with /va.